### PR TITLE
fix minor bug

### DIFF
--- a/md2canvas/md2canvas/md2json.py
+++ b/md2canvas/md2canvas/md2json.py
@@ -599,7 +599,7 @@ def parse_quiz(nb_file):
     elif nb_file.endswith(".ipynb"):
         jupytext(args=[str(nb_file), "--to", "md:myst"])
         nb_file = nb_file.replace(".ipynb", ".md")
-    nb_obj = jp.readf(nb_file)
+    nb_obj = jp.read(nb_file)
 
     quiz = {"attrs": {}, "groups": []}
 


### PR DESCRIPTION
Fixed bug causing `AttributeError: module 'jupytext' has no attribute 'readf'`.


Trace from before the fix:
```
Traceback (most recent call last):
  File "/Users/carolzhang/miniconda3/envs/quiz-mill/bin/md2canvas", line 8, in <module>
    sys.exit(md2canvas())
  File "/Users/carolzhang/miniconda3/envs/quiz-mill/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/carolzhang/miniconda3/envs/quiz-mill/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/carolzhang/miniconda3/envs/quiz-mill/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/carolzhang/miniconda3/envs/quiz-mill/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/carolzhang/miniconda3/envs/quiz-mill/lib/python3.8/site-packages/md2canvas/command.py", line 106, in md2canvas
    quiz = m2j.parse_quiz(notebook_file)
  File "/Users/carolzhang/miniconda3/envs/quiz-mill/lib/python3.8/site-packages/md2canvas/md2json.py", line 602, in parse_quiz
    nb_obj = jp.readf(nb_file)
AttributeError: module 'jupytext' has no attribute 'readf'
```